### PR TITLE
Fix compilation after update to angular 10

### DIFF
--- a/projects/ngx-summernote/src/lib/ngx-summernote.module.ts
+++ b/projects/ngx-summernote/src/lib/ngx-summernote.module.ts
@@ -13,7 +13,7 @@ import { NgxSummernoteViewDirective } from './ngx-summernote-view.directive';
   ]
 })
 export class NgxSummernoteModule {
-  public static forRoot(): ModuleWithProviders {
+  public static forRoot(): ModuleWithProviders<NgxSummernoteModule> {
     return {ngModule: NgxSummernoteModule,  providers: []};
   }
 }


### PR DESCRIPTION
This error comes from the build (i'm using CircleCI):
ERROR in node_modules/ngx-summernote/lib/ngx-summernote.module.d.ts:3:23 - error TS2314: Generic type 'ModuleWithProviders<T>' requires 1 type argument(s).