### PR TITLE
Add dialogsInBody into SummernoteOptions.

### DIFF
--- a/projects/ngx-summernote/src/lib/summernote-options.ts
+++ b/projects/ngx-summernote/src/lib/summernote-options.ts
@@ -26,4 +26,5 @@ export interface SummernoteOptions {
   airMode?: boolean;
   popover?: any;
   dialogsInBody?: boolean;
+  lang?: string;
 }

--- a/projects/ngx-summernote/src/lib/summernote-options.ts
+++ b/projects/ngx-summernote/src/lib/summernote-options.ts
@@ -25,4 +25,5 @@ export interface SummernoteOptions {
   buttons?: any;
   airMode?: boolean;
   popover?: any;
+  dialogsInBody?: boolean;
 }

--- a/projects/ngx-summernote/src/lib/summernote-options.ts
+++ b/projects/ngx-summernote/src/lib/summernote-options.ts
@@ -27,4 +27,5 @@ export interface SummernoteOptions {
   popover?: any;
   dialogsInBody?: boolean;
   lang?: string;
+  fontNamesIgnoreCheck?: string[];
 }


### PR DESCRIPTION
Add the missing option "dialogsInBody" into the option interface "SummernoteOptions".