### PR TITLE
fix updateEditor method

### DIFF
--- a/projects/ngx-summernote/src/lib/ngx-summernote.directive.ts
+++ b/projects/ngx-summernote/src/lib/ngx-summernote.directive.ts
@@ -158,7 +158,7 @@ export class NgxSummernoteDirective
     if (this._editorInitialized) {
       this._$element.summernote('code', content);
     } else {
-      this._$element.html(content);
+      this._$element?.html(content);
     }
   }
 


### PR DESCRIPTION
Somehow `updateEditor` method is triggered probably after onDestroy, which causes error in console, added fix to avoid it, please merge. 